### PR TITLE
Option to force application chooser when share

### DIFF
--- a/src/android/IntentShim.java
+++ b/src/android/IntentShim.java
@@ -570,6 +570,10 @@ public class IntentShim extends CordovaPlugin {
 
         i.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
 
+        if (obj.has("chooser")) {
+            i = Intent.createChooser(i, obj.getString("chooser"));
+        }
+
         return i;
     }
 


### PR DESCRIPTION
Additional field "chooser" in StartActivity and StartActivityForResult forces application selection dialog. It may be useful for ACTION_SEND intent. The string value of the field is used as a chooser dialog title.
Ex: window.plugins.intentShim.startActivity(
            {
                action: window.plugins.intentShim.ACTION_SEND,
                type: 'text/*',
                extras: {
                    "android.intent.extra.TEXT": artworkUrl,
                },
                chooser: "Select application to share",
            }
        );